### PR TITLE
Sortable fields with scope:name_of_scope

### DIFF
--- a/lib/jsonapi/scopes/filters.rb
+++ b/lib/jsonapi/scopes/filters.rb
@@ -20,7 +20,6 @@ module Jsonapi
 
         filtering_params.each do |key, value|
           value = value.to_s.split(',').reject(&:blank?) if value.include?(',')
-          value = value.join if value.is_a? Array
 
           raise InvalidAttributeError, "#{key} is not valid as filter attribute." unless @filters.include?(key.to_sym)
 

--- a/lib/jsonapi/scopes/filters.rb
+++ b/lib/jsonapi/scopes/filters.rb
@@ -20,6 +20,7 @@ module Jsonapi
 
         filtering_params.each do |key, value|
           value = value.to_s.split(',').reject(&:blank?) if value.include?(',')
+          value = value.join if value.is_a? Array
 
           raise InvalidAttributeError, "#{key} is not valid as filter attribute." unless @filters.include?(key.to_sym)
 

--- a/lib/jsonapi/scopes/filters.rb
+++ b/lib/jsonapi/scopes/filters.rb
@@ -19,7 +19,7 @@ module Jsonapi
         filtering_params = params.dig(:filter) || {}
 
         filtering_params.each do |key, value|
-          value = value.to_s.split(',').reject(&:blank?) if value.include?(',')
+          value = value.to_s.split(',').reject(&:blank?) if value&.include?(',')
 
           raise InvalidAttributeError, "#{key} is not valid as filter attribute." unless @filters.include?(key.to_sym)
 

--- a/lib/jsonapi/scopes/includes.rb
+++ b/lib/jsonapi/scopes/includes.rb
@@ -26,7 +26,7 @@ module Jsonapi
           raise InvalidAttributeError, "#{field} is not valid as include attribute." unless allowed_fields.include?(field)
         end
 
-        preload_fields = a_fields.select { |field| reflect_on_association(field).polymorphic? }
+        preload_fields = a_fields.select { |field| reflect_on_association(field)&.polymorphic? }
         include_fields = a_fields - preload_fields
         records.includes(convert_includes_as_hash(include_fields.join(',')))
         records.preload(convert_includes_as_hash(preload_fields.join(',')))

--- a/lib/jsonapi/scopes/includes.rb
+++ b/lib/jsonapi/scopes/includes.rb
@@ -28,7 +28,7 @@ module Jsonapi
 
         preload_fields = a_fields.select { |field| reflect_on_association(field)&.polymorphic? }
         include_fields = a_fields - preload_fields
-        records.includes(convert_includes_as_hash(include_fields.join(',')))
+        records = records.includes(convert_includes_as_hash(include_fields.join(',')))
         records.preload(convert_includes_as_hash(preload_fields.join(',')))
       end
 

--- a/lib/jsonapi/scopes/includes.rb
+++ b/lib/jsonapi/scopes/includes.rb
@@ -21,11 +21,15 @@ module Jsonapi
 
         allowed_fields = (Array.wrap(options[:allowed]).presence || @allowed_includes).map(&:to_s)
 
-        fields.split(',').each do |field|
+        a_fields = fields.split(',')
+        a_fields.each do |field|
           raise InvalidAttributeError, "#{field} is not valid as include attribute." unless allowed_fields.include?(field)
         end
 
-        records.includes(convert_includes_as_hash(fields))
+        preload_fields = a_fields.select { |field| reflect_on_association(field).polymorphic? }
+        include_fields = a_fields - preload_fields
+        records.includes(convert_includes_as_hash(include_fields.join(',')))
+        records.preload(convert_includes_as_hash(preload_fields.join(',')))
       end
 
       private

--- a/lib/jsonapi/scopes/includes.rb
+++ b/lib/jsonapi/scopes/includes.rb
@@ -13,6 +13,8 @@ module Jsonapi
         @allowed_includes = fields
       end
 
+      def allowed_includes_list = @allowed_includes
+
       def apply_include(params = {}, options = { allowed: [] })
         records = all
         fields = params.dig(:include).to_s

--- a/lib/jsonapi/scopes/sorts.rb
+++ b/lib/jsonapi/scopes/sorts.rb
@@ -29,9 +29,20 @@ module Jsonapi
           raise InvalidAttributeError, "#{field} is not valid as sort attribute." unless allowed_fields.include?(field)
         end
 
-        order = ordered_fields.presence || default_order
+        res = self
 
-        self.order(order)
+        order_to_follow = ordered_fields.presence || default_order
+        order_to_follow.each do |single_order_q, direction|
+          if single_order_q.to_s.include? 'scope:'
+            scope_name = single_order_q.to_s.split(':').last
+
+            res = send(scope_name.to_sym, direction)
+          else
+            res = order("#{single_order_q}": direction)
+          end
+        end
+
+        res
       end
 
       private

--- a/lib/jsonapi/scopes/sorts.rb
+++ b/lib/jsonapi/scopes/sorts.rb
@@ -29,16 +29,16 @@ module Jsonapi
           raise InvalidAttributeError, "#{field} is not valid as sort attribute." unless allowed_fields.include?(field)
         end
 
-        res = self
+        res = all
 
         order_to_follow = ordered_fields.presence || default_order
         order_to_follow.each do |single_order_q, direction|
           if single_order_q.to_s.include? 'scope:'
             scope_name = single_order_q.to_s.split(':').last
 
-            res = send(scope_name.to_sym, direction)
+            res = res.send(scope_name.to_sym, direction)
           else
-            res = order("#{single_order_q}": direction)
+            res = res.order("#{single_order_q}": direction)
           end
         end
 

--- a/test/dummy/spec/models/user_spec.rb
+++ b/test/dummy/spec/models/user_spec.rb
@@ -11,6 +11,26 @@ RSpec.describe User, type: :model do
     it 'responds to allowed_includes' do
       expect(User).to respond_to(:allowed_includes)
     end
+
+    it 'responds to allowed_includes_list' do
+      expect(User).to respond_to(:allowed_includes_list)
+    end
+  end
+
+  describe '#allowed_includes_list' do
+    after do
+      User.allowed_includes 'contact', 'posts.contact.users', 'posts', 'posts.user'
+    end
+
+    it 'returns the configured allowed includes' do
+      expect(User.allowed_includes_list).to eq(['contact', 'posts.contact.users', 'posts', 'posts.user'])
+    end
+
+    it 'reflects updates made through allowed_includes' do
+      User.allowed_includes 'contact', 'posts'
+
+      expect(User.allowed_includes_list).to eq(['contact', 'posts'])
+    end
   end
 
   describe '#apply_include' do


### PR DESCRIPTION
You can sort things like this:
![image](https://github.com/guillaumebriday/jsonapi-scopes/assets/2974561/5f4b3ca4-101a-49c3-8c6e-c522c6315021)

EDIT: The array in this position seems needed to filters with dates so reverted.